### PR TITLE
Change MAC address input format

### DIFF
--- a/GCodes.cpp
+++ b/GCodes.cpp
@@ -1244,7 +1244,7 @@ void GCodes::SetMACAddress(GCodeBuffer *gb)
 	{
 		if(ipString[sp] == ':')
 		{
-			mac[ipp] = strtol(&ipString[spp], NULL, 0);
+			mac[ipp] = strtol(&ipString[spp], NULL, 16);
 			ipp++;
 			if(ipp > 5)
 			{
@@ -1258,7 +1258,7 @@ void GCodes::SetMACAddress(GCodeBuffer *gb)
 		}else
 			sp++;
 	}
-	mac[ipp] = strtol(&ipString[spp], NULL, 0);
+	mac[ipp] = strtol(&ipString[spp], NULL, 16);
 	if(ipp == 5)
 	{
 		platform->SetMACAddress(mac);


### PR DESCRIPTION
Set the base of strtol to 16 when parsing MAC address. This means the address can be specified in the much more human-friendly format

M540 PBE:EF:12:34:56:78

The variant with "0x" preceding each byte still works just as earlier, this small change just makes the 0x optional.