### PR TITLE
Add check for missing keys in local storage when loading settings.

### DIFF
--- a/SD-image-Ormerod-2/www/reprap.js
+++ b/SD-image-Ormerod-2/www/reprap.js
@@ -476,16 +476,16 @@ function loadSettings() {
     $('div#headTemperature1 ul').html('<li class="divider"></li><li><a href="#" id="addHeadTemp1">Add Temp</a></li>');
     $('div#headTemperature2 ul').html('<li class="divider"></li><li><a href="#" id="addHeadTemp2">Add Temp</a></li>');
     $('div#headTemperature3 ul').html('<li class="divider"></li><li><a href="#" id="addHeadTemp3">Add Temp</a></li>');
-    storage.get('temps', 'bed').forEach(function(item){
+    (storage.get('temps', 'bed')||[]).forEach(function(item){
         $('div#bedTemperature ul').prepend('<li><a href="#" id="bedTempLink">'+item+'</a></li>');
     });
-    storage.get('temps', 'head1').forEach(function(item){
+    (storage.get('temps', 'head1')||[]).forEach(function(item){
         $('div#headTemperature1 ul').prepend('<li><a href="#" id="headTempLink1">'+item+'</a></li>');
     });
-	 storage.get('temps', 'head2').forEach(function(item){
+    (storage.get('temps', 'head2')||[]).forEach(function(item){
         $('div#headTemperature2 ul').prepend('<li><a href="#" id="headTempLink2">'+item+'</a></li>');
     });
-	 storage.get('temps', 'head3').forEach(function(item){
+    (storage.get('temps', 'head3')||[]).forEach(function(item){
         $('div#headTemperature3 ul').prepend('<li><a href="#" id="headTempLink3">'+item+'</a></li>');
     });
 }


### PR DESCRIPTION
Some keys expected by updated JavaScript are missing
when loading settings from local storage after
upgrading firmware to version 1.04.
For example, storage.get('temps', 'head1') returns undefined,
so applying forEach method to it causes error and prevents
further JavaScript initialisation.

This problem manifests as "Connect" button disabled
after updating firmware and corresponding files on SD card
to version 1.04.

This change adds check for return value of storage.get(...)
and replaces it with empty array in all places where
forEach method is called on this value.